### PR TITLE
Add linux/arm64 Docker image builds

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -60,6 +60,9 @@ jobs:
             type=edge,enable=${{ steps.is-head-main.outcome == 'success' }}
             type=ref,event=branch,enable=${{ github.event_name == 'workflow_dispatch' }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -103,6 +106,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags || 'edge' }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add QEMU emulation step to enable cross-platform Docker builds
- Build and push multi-platform images (`linux/amd64` + `linux/arm64`)
- Add build cache to the push step for faster rebuilds

Closes #42

## Test plan
- [ ] Verify the workflow runs successfully on push to main
- [ ] Verify published images include both `linux/amd64` and `linux/arm64` manifests (`docker manifest inspect`)