### PR TITLE
fix: scope config.toml gitignore to repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ target/
 
 .idea
 .vscode
-config.toml
+/config.toml


### PR DESCRIPTION
## Summary
- Fixes release-plz CI failure caused by `config.toml` gitignore pattern matching the tracked file `conf/config.toml`
- Changes `config.toml` to `/config.toml` so it only ignores the root-level runtime config, not the one in `conf/`

## Context
The pattern was added in #70 when flattening the crate structure. The unscoped pattern inadvertently matched `conf/config.toml`, causing release-plz to error with: *"the working directory of this project has uncommitted changes: conf/config.toml"*

## Test plan
- [ ] Verify release-plz workflow succeeds after merge