### PR TITLE
fix: use GB instead of GiB in API description

### DIFF
--- a/api-description.yaml
+++ b/api-description.yaml
@@ -147,7 +147,7 @@ paths:
         "404":
           description: "Partially uploaded file does not exist."
         "413":
-          description: "The upload exceeds the per-upload size limit (5 GiB)."
+          description: "The upload exceeds the per-upload size limit (5 GB)."
           content:
             application/json:
               schema:
@@ -197,7 +197,7 @@ paths:
         "404":
           description: "Partially upload file does not exist."
         "413":
-          description: "The sender has exceeded the rolling 14-day upload limit (15 GiB)."
+          description: "The sender has exceeded the rolling 14-day upload limit (15 GB)."
           content:
             application/json:
               schema:
@@ -247,14 +247,14 @@ paths:
                   limit_bytes:
                     type: "integer"
                     format: "int64"
-                    description: "Rolling-window upload limit in bytes (15 GiB)."
+                    description: "Rolling-window upload limit in bytes (15 GB)."
                   window_days:
                     type: "integer"
                     description: "Length of the rolling window in days."
                   per_upload_limit_bytes:
                     type: "integer"
                     format: "int64"
-                    description: "Maximum size of a single upload in bytes (5 GiB)."
+                    description: "Maximum size of a single upload in bytes (5 GB)."
                   resets_at:
                     type: "string"
                     format: "date-time"


### PR DESCRIPTION
## Summary
- Replace all GiB references with GB in `api-description.yaml`

## Test plan
- [x] Verify API docs render correctly with GB labels