### PR TITLE
fix: align upload limits to round GB values

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -8,10 +8,10 @@ use std::{
 
 use rocket::tokio::{sync::Notify, time::Instant};
 
-pub const PER_UPLOAD_LIMIT: u64 = 5 * 1024 * 1024 * 1024;
-pub const ROLLING_LIMIT: u64 = 5 * 1024 * 1024 * 1024;
-pub const API_KEY_PER_UPLOAD_LIMIT: u64 = 100 * 1024 * 1024 * 1024;
-pub const API_KEY_ROLLING_LIMIT: u64 = 100 * 1024 * 1024 * 1024;
+pub const PER_UPLOAD_LIMIT: u64 = 5_000_000_000;
+pub const ROLLING_LIMIT: u64 = 5_000_000_000;
+pub const API_KEY_PER_UPLOAD_LIMIT: u64 = 100_000_000_000;
+pub const API_KEY_ROLLING_LIMIT: u64 = 100_000_000_000;
 pub const ROLLING_WINDOW_SECS: i64 = 14 * 24 * 60 * 60;
 
 pub struct FileState {


### PR DESCRIPTION
## Summary
- Change server-side limits from binary (5 GiB = 5,368,709,120) to decimal (5 GB = 5,000,000,000)
- Same for API key limits: 100 GiB → 100 GB

Companion PR: encryption4all/postguard-website#115

## Test plan
- [ ] Verify upload limit enforcement works with the new byte values