### PR TITLE
feat: configurable chunk size via TOML config (default 5 MB)

### DIFF
--- a/conf/config.dev.toml
+++ b/conf/config.dev.toml
@@ -14,3 +14,4 @@ usage_db = "/app/data/usage.db"
 # pkg_url = "https://postguard-main.cs.ru.nl/pkg"
 # pkg_url = "https://pkg.staging.yivi.app"
 pkg_url = "http://postguard-pkg:8087"
+chunk_size = 5000000

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct RawCryptifyConfig {
     smtp_tls: Option<bool>,
     allowed_origins: String,
     pkg_url: String,
+    chunk_size: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -27,6 +28,7 @@ pub struct CryptifyConfig {
     smtp_tls: bool,
     allowed_origins: String,
     pkg_url: String,
+    chunk_size: u64,
 }
 
 impl From<RawCryptifyConfig> for CryptifyConfig {
@@ -45,6 +47,7 @@ impl From<RawCryptifyConfig> for CryptifyConfig {
             smtp_tls: config.smtp_tls.unwrap_or(true),
             allowed_origins: config.allowed_origins,
             pkg_url: config.pkg_url,
+            chunk_size: config.chunk_size.unwrap_or(5_000_000),
         }
     }
 }
@@ -88,5 +91,9 @@ impl CryptifyConfig {
 
     pub fn pkg_url(&self) -> &str {
         &self.pkg_url
+    }
+
+    pub fn chunk_size(&self) -> u64 {
+        self.chunk_size
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,6 @@ use rocket_cors::{AllowedOrigins, CorsOptions};
 use serde::{Deserialize, Serialize};
 use store::{FileState, Store};
 
-const CHUNK_SIZE: u64 = 10 * 1024 * 1024; // 10 MiB
-
 #[derive(Serialize, Deserialize)]
 struct InitBody {
     recipient: String,
@@ -308,9 +306,9 @@ async fn upload_chunk(
         )));
     }
 
-    if end - start > CHUNK_SIZE {
+    if end - start > config.chunk_size() {
         return Err(Error::BadRequest(Some(
-            "File chunk too large; the maximum is 10 MiB".to_owned(),
+            format!("File chunk too large; the maximum is {} bytes", config.chunk_size()),
         )));
     }
 
@@ -544,22 +542,24 @@ fn usage(store: &State<Store>, api_key: ApiKeyPresent, email: String) -> Json<Us
 
 #[launch]
 async fn rocket() -> _ {
+    // Extract config first so we can use chunk_size for Rocket's body-size limits.
+    let config = rocket::Config::figment()
+        .extract::<CryptifyConfig>()
+        .expect("Missing configuration");
+
     // Raise Rocket's default body-size limits so chunked uploads up to
-    // CHUNK_SIZE do not trip "Data limit reached while reading the request
+    // chunk_size do not trip "Data limit reached while reading the request
     // body". `data.open((end - start).bytes())` already caps the per-request
     // read; this lifts the framework-level cap that runs before it.
-    // A small headroom above CHUNK_SIZE leaves room for HTTP overhead.
+    // A small headroom above chunk_size leaves room for HTTP overhead.
+    let chunk_size = config.chunk_size();
     let limits = rocket::data::Limits::default()
-        .limit("bytes", (CHUNK_SIZE + 1024 * 1024).bytes())
-        .limit("data-form", (CHUNK_SIZE + 1024 * 1024).bytes())
-        .limit("file", (CHUNK_SIZE + 1024 * 1024).bytes());
+        .limit("bytes", (chunk_size + 1024 * 1024).bytes())
+        .limit("data-form", (chunk_size + 1024 * 1024).bytes())
+        .limit("file", (chunk_size + 1024 * 1024).bytes());
 
     let figment = rocket::Config::figment().merge(("limits", limits));
     let rocket = rocket::custom(figment);
-    let config = rocket
-        .figment()
-        .extract::<CryptifyConfig>()
-        .expect("Missing configuration");
 
     let pkg_params_url = format!("{}/v2/sign/parameters", config.pkg_url());
     let response = minreq::get(&pkg_params_url)


### PR DESCRIPTION
## Summary
- Remove the hardcoded `CHUNK_SIZE` constant (was 10 MiB) from `main.rs`
- Add an optional `chunk_size` field to `CryptifyConfig` in `config.rs`, defaulting to 5,000,000 bytes (5 MB) when not specified in TOML
- Update `upload_chunk` validation and Rocket body-size limits to use the configured value
- Add `chunk_size = 5000000` example to `conf/config.dev.toml`

## Test plan
- [ ] Verify `cargo check` passes (done locally)
- [ ] Deploy with no `chunk_size` in TOML and confirm the default 5 MB limit applies
- [ ] Deploy with a custom `chunk_size` value and confirm it is respected
- [ ] Upload a chunk exceeding the configured limit and verify the error message shows the correct byte count