### PR TITLE
feat(upload): add notifyRecipients toggle on /fileupload/init

### DIFF
--- a/api-description.yaml
+++ b/api-description.yaml
@@ -65,6 +65,11 @@ paths:
                     type: "boolean"
                     example: true
                     description: "Whether to send a confirmation email to the sender"
+                  notifyRecipients:
+                    type: "boolean"
+                    default: true
+                    example: true
+                    description: "Whether to email each recipient with a download link. Optional; defaults to true. Set to false to upload silently when the encrypted payload reaches recipients through another channel and a Cryptify-sent notification would be a duplicate."
         responses:
           "200":
             description: "Successful operation"

--- a/src/email.rs
+++ b/src/email.rs
@@ -215,31 +215,39 @@ pub async fn send_email(
         mailer_builder = mailer_builder.credentials(credentials);
     }
 
-    for recipient in state.recipients.iter() {
-        // combine URL with mail variables into template
-        let base = Url::parse(config.server_url())?;
-        let mut url = base.join("/download")?;
-        url.query_pairs_mut()
-            .append_pair("uuid", uuid)
-            .append_pair("recipient", &format!("{}", recipient.email));
+    if state.notify_recipients {
+        for recipient in state.recipients.iter() {
+            // combine URL with mail variables into template
+            let base = Url::parse(config.server_url())?;
+            let mut url = base.join("/download")?;
+            url.query_pairs_mut()
+                .append_pair("uuid", uuid)
+                .append_pair("recipient", &format!("{}", recipient.email));
 
-        let (email, subject) = email_templates(state, url.as_str());
-        let email = Message::builder()
-            .header(ContentType::TEXT_HTML)
-            .header(XPostGuard(X_POSTGUARD_VERSION.to_owned()))
-            .from(config.email_from()) // checked in config
-            .to(recipient.clone())
-            .subject(subject)
-            .body(email)?;
+            let (email, subject) = email_templates(state, url.as_str());
+            let email = Message::builder()
+                .header(ContentType::TEXT_HTML)
+                .header(XPostGuard(X_POSTGUARD_VERSION.to_owned()))
+                .from(config.email_from()) // checked in config
+                .to(recipient.clone())
+                .subject(subject)
+                .body(email)?;
 
-        // send email
-        log::info!("Sending email to {}", recipient.email);
-        let mailer = mailer_builder.clone().build();
-        mailer.send(&email).map_err(|e| {
-            log::error!("Failed to send email to {}: {}", recipient.email, e);
-            e
-        })?;
-        log::info!("Email sent to {}", recipient.email);
+            // send email
+            log::info!("Sending email to {}", recipient.email);
+            let mailer = mailer_builder.clone().build();
+            mailer.send(&email).map_err(|e| {
+                log::error!("Failed to send email to {}: {}", recipient.email, e);
+                e
+            })?;
+            log::info!("Email sent to {}", recipient.email);
+        }
+    } else {
+        log::info!(
+            "notify_recipients disabled — skipping notification mail for {} recipient(s) on upload {}",
+            state.recipients.iter().count(),
+            uuid
+        );
     }
 
     if state.confirm {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,19 @@ struct InitBody {
     #[serde(rename = "mailLang")]
     mail_lang: email::Language,
     confirm: bool,
+    /// Whether to email each recipient with a download link. Optional;
+    /// defaults to `true` to preserve existing client behaviour. Set to
+    /// `false` when the encrypted payload reaches the recipients through
+    /// another channel (e.g. an email add-in delivering the message from
+    /// the user's own mailbox) and a Cryptify-sent notification would be
+    /// a duplicate. The recipient list itself is still validated and
+    /// stored — only the SMTP delivery is skipped.
+    #[serde(rename = "notifyRecipients", default = "default_true")]
+    notify_recipients: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Serialize, Deserialize)]
@@ -121,6 +134,7 @@ async fn upload_init(
                     sender: None,
                     sender_attributes: Vec::new(),
                     confirm: request.confirm,
+                    notify_recipients: request.notify_recipients,
                     is_api_key: api_key.0,
                 },
             );

--- a/src/store.rs
+++ b/src/store.rs
@@ -24,6 +24,11 @@ pub struct FileState {
     pub sender: Option<String>,
     pub sender_attributes: Vec<(String, String)>,
     pub confirm: bool,
+    /// When false, the recipient notification email is suppressed (the
+    /// recipients still appear in the parsed list, but the SMTP delivery
+    /// loop in `send_email` is skipped). The sender confirmation, if
+    /// `confirm` is true, is sent regardless.
+    pub notify_recipients: bool,
     pub is_api_key: bool,
 }
 


### PR DESCRIPTION
## Summary

Today `/fileupload/init` always queues a per-recipient notification email; there's no way for a client to upload silently. That's a problem when the encrypted payload reaches recipients through another channel (e.g. an email add-in delivering the message from the sender's own mailbox) — the Cryptify mail then arrives as a duplicate of the user's own message. (Filed alongside [postguard-js#40](https://github.com/encryption4all/postguard-js/issues/40); coordinated client changes follow in pg-js and postguard-dotnet.)

## API change

Adds an optional `notifyRecipients` field to the `/fileupload/init` request body:

\`\`\`jsonc
{
  \"recipient\": \"alice@example.com\",
  \"mailContent\": \"\",
  \"mailLang\": \"EN\",
  \"confirm\": false,
  \"notifyRecipients\": false   // new — defaults to true if omitted
}
\`\`\`

| field | default | effect |
| --- | --- | --- |
| `confirm` | `false` | sender confirmation email |
| `notifyRecipients` | `true` | per-recipient notification email — **new flag** |
| `mailContent` | `\"\"` | unencrypted text included in *both* notification mails |

Defaults preserve the long-standing behaviour for clients that don't know about the new flag. Spec updated in `api-description.yaml`.

## Server change

`upload_init` plumbs `notify_recipients` into `FileState`. `send_email` now branches on it; the recipient list is still parsed by `request.recipient.parse::<Mailboxes>()` and stored, only the SMTP delivery loop is gated.

## Backward compatibility

- Clients that don't send `notifyRecipients` get `default = true` via `serde(default)`, identical to today's behaviour.
- Cryptify-as-fileshare (where the recipient mail *is* the delivery mechanism) keeps working unchanged.
- The sender confirmation toggle is independent: a caller can request `notifyRecipients: false, confirm: true` to suppress recipient mails while keeping a sender record, or vice versa.

## Test plan

- [ ] Existing client (no `notifyRecipients` field) → recipient still receives notification email. Body is identical to before.
- [ ] New client with `notifyRecipients: false` → recipient receives no email; log line `notify_recipients disabled — skipping notification mail` appears with the correct recipient count.
- [ ] `notifyRecipients: false, confirm: true` → sender confirmation email is delivered; no recipient mails.
- [ ] `notifyRecipients: false` with malformed `recipient` string → still rejects with 400 (validation runs before the toggle is consulted).