### PR TITLE
ci: add Rust quality job (fmt, clippy, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,27 @@ on:
 
 jobs:
 
+  # Rust quality gate: fmt, clippy, tests. Runs on every PR and on push to
+  # main, in parallel to the release-plz/Docker pipeline (does not block it).
+  quality:
+    name: Rust quality (fmt, clippy, test)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Cache cargo registry and target
+        uses: Swatinem/rust-cache@v2
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings
+      - name: cargo test
+        run: cargo test --all-targets
+
   # Release unpublished packages.
   release-plz-release:
     name: Release-plz release


### PR DESCRIPTION
## Summary
- Adds a `quality` job to `.github/workflows/ci.yml` that runs `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test --all-targets` on every PR and on push to `main`.
- Runs in parallel to the existing release-plz / Docker pipeline; does not block it.
- Implements step 3 from #126 — the patch dobby-coder verified locally but [could not push](https://github.com/encryption4all/cryptify/issues/126#issuecomment-4380018000) due to missing `workflows: write` permission on the GitHub App.

## Local verification on `main`@`a058c3d` + this change
| Step | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test --all-targets` | 30 passed, 0 failed |

## Test plan
- [ ] CI `quality` job runs and passes on this PR
- [ ] Existing release-plz / Docker pipeline still runs unchanged on push to `main`

Closes #126.