### PR TITLE
feat(upload): structured 404 body + configurable session TTL

### DIFF
--- a/api-description.yaml
+++ b/api-description.yaml
@@ -150,7 +150,16 @@ paths:
                     message:
                       type: "string"
         "404":
-          description: "Partially uploaded file does not exist."
+          description:
+            "The upload session is not known to the server. Either the
+            client never called `/fileupload/init`, the session was idle
+            past the configured TTL and got evicted, or the on-disk file
+            has been removed. Clients should not retry — start a new
+            upload via `/fileupload/init`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadSessionNotFound"
         "413":
           description: "The upload exceeds the per-upload size limit (5 GB for non-API-key uploads, 100 GB for API-key uploads)."
           content:
@@ -200,7 +209,14 @@ paths:
                     message:
                       type: "string"
         "404":
-          description: "Partially upload file does not exist."
+          description:
+            "The upload session is not known to the server (see
+            `/fileupload/{uuid}` 404 for details). Clients should not
+            retry — start a new upload via `/fileupload/init`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadSessionNotFound"
         "413":
           description: "The sender has exceeded the rolling 14-day upload limit (5 GB for non-API-key uploads, 100 GB for API-key uploads)."
           content:
@@ -333,3 +349,32 @@ components:
           type: "integer"
           format: "int64"
           description: "The limit value in bytes."
+    UploadSessionNotFound:
+      type: "object"
+      required:
+        - error
+        - uuid
+        - reason
+      properties:
+        error:
+          type: "string"
+          enum:
+            - "upload_session_not_found"
+          description: "Stable machine-readable error code for clients."
+        uuid:
+          type: "string"
+          format: "uuid"
+          description: "The upload UUID the request targeted."
+        reason:
+          type: "string"
+          enum:
+            - "expired_or_unknown"
+            - "invalid_uuid"
+            - "file_missing"
+          description:
+            "Why the session is not retrievable. `expired_or_unknown`
+            means the session was either evicted after its idle TTL or
+            never existed (clients cannot tell these apart, by design).
+            `invalid_uuid` means the path UUID is malformed.
+            `file_missing` means the in-memory session exists but the
+            on-disk file is gone (server-state inconsistency)."

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub struct RawCryptifyConfig {
     allowed_origins: String,
     pkg_url: String,
     chunk_size: Option<u64>,
+    session_ttl_secs: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -29,6 +30,7 @@ pub struct CryptifyConfig {
     allowed_origins: String,
     pkg_url: String,
     chunk_size: u64,
+    session_ttl_secs: u64,
 }
 
 impl From<RawCryptifyConfig> for CryptifyConfig {
@@ -48,6 +50,7 @@ impl From<RawCryptifyConfig> for CryptifyConfig {
             allowed_origins: config.allowed_origins,
             pkg_url: config.pkg_url,
             chunk_size: config.chunk_size.unwrap_or(5_000_000),
+            session_ttl_secs: config.session_ttl_secs.unwrap_or(3600),
         }
     }
 }
@@ -95,5 +98,9 @@ impl CryptifyConfig {
 
     pub fn chunk_size(&self) -> u64 {
         self.chunk_size
+    }
+
+    pub fn session_ttl_secs(&self) -> u64 {
+        self.session_ttl_secs
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,13 @@ pub struct PayloadTooLargeBody {
     pub resets_at: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct UploadSessionNotFoundBody {
+    pub error: &'static str,
+    pub uuid: String,
+    pub reason: &'static str,
+}
+
 #[derive(Debug)]
 pub enum Error {
     BadRequest(Option<String>),
@@ -26,6 +33,17 @@ pub enum Error {
     /// tier and we couldn't confirm the caller is entitled to the higher
     /// tier. Smaller uploads degrade silently to the default tier.
     ServiceUnavailable(Option<String>),
+    UploadSessionNotFound(UploadSessionNotFoundBody),
+}
+
+impl Error {
+    pub fn upload_session_not_found(uuid: impl Into<String>, reason: &'static str) -> Self {
+        Error::UploadSessionNotFound(UploadSessionNotFoundBody {
+            error: "upload_session_not_found",
+            uuid: uuid.into(),
+            reason,
+        })
+    }
 }
 
 impl<'r, 'o: 'r> Responder<'r, 'o> for Error {
@@ -54,6 +72,12 @@ impl<'r, 'o: 'r> Responder<'r, 'o> for Error {
                 e.unwrap_or_else(|| "".to_owned()),
             )
             .respond_to(request),
+            Error::UploadSessionNotFound(body) => {
+                response::Response::build_from(Json(body).respond_to(request)?)
+                    .status(rocket::http::Status::NotFound)
+                    .header(ContentType::JSON)
+                    .ok()
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -436,15 +436,15 @@ async fn upload_chunk(
     uuid: &str,
     headers: UploadHeaders,
     data: Data<'_>,
-) -> Result<Option<UploadResponder>, Error> {
+) -> Result<UploadResponder, Error> {
     let state = match store.get(uuid) {
         Some(v) => v,
-        None => return Ok(None),
+        None => return Err(Error::upload_session_not_found(uuid, "expired_or_unknown")),
     };
     let mut state = state.lock().await;
 
     if uuid::Uuid::parse_str(uuid).is_err() {
-        return Ok(None);
+        return Err(Error::upload_session_not_found(uuid, "invalid_uuid"));
     }
 
     let start = headers
@@ -505,7 +505,7 @@ async fn upload_chunk(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(_) => return Err(Error::upload_session_not_found(uuid, "file_missing")),
     };
 
     file.seek(std::io::SeekFrom::Start(start))
@@ -534,10 +534,10 @@ async fn upload_chunk(
     drop(state);
     store.touch(uuid);
 
-    Ok(Some(UploadResponder {
+    Ok(UploadResponder {
         body: (),
         cryptify_token: CryptifyToken(shasum),
-    }))
+    })
 }
 
 struct FinalizeHeaders {
@@ -593,10 +593,10 @@ async fn upload_finalize(
     vk: &State<Parameters<VerifyingKey>>,
     headers: FinalizeHeaders,
     uuid: &str,
-) -> Result<Option<()>, Error> {
+) -> Result<(), Error> {
     let state = match store.get(uuid) {
         Some(v) => v,
-        None => return Ok(None),
+        None => return Err(Error::upload_session_not_found(uuid, "expired_or_unknown")),
     };
     let mut state = state.lock().await;
 
@@ -693,7 +693,7 @@ async fn upload_finalize(
         store.record_upload(key, state.uploaded, now_secs);
     }
 
-    Ok(Some(()))
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -795,7 +795,9 @@ async fn rocket() -> _ {
         )
         .mount("/filedownload", FileServer::from(config.data_dir()))
         .attach(AdHoc::config::<CryptifyConfig>())
-        .manage(Store::new())
+        .manage(Store::with_idle_ttl(std::time::Duration::from_secs(
+            config.session_ttl_secs(),
+        )))
         .manage(vk)
         .manage(pkg_client)
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -14,10 +14,12 @@ pub const API_KEY_PER_UPLOAD_LIMIT: u64 = 100_000_000_000;
 pub const API_KEY_ROLLING_LIMIT: u64 = 100_000_000_000;
 pub const ROLLING_WINDOW_SECS: i64 = 14 * 24 * 60 * 60;
 
-/// Idle window for an in-memory upload session. Each successful chunk PUT
-/// resets it; if no activity is seen for this long the session is evicted
-/// (the on-disk file is left alone — `FileState.expires` covers that).
-pub const UPLOAD_SESSION_IDLE_TIMEOUT_SECS: u64 = 60 * 60;
+/// Default idle window for an in-memory upload session when no value is
+/// provided in config. Each successful chunk PUT resets it; if no activity
+/// is seen for this long the session is evicted (the on-disk file is left
+/// alone — `FileState.expires` covers that).
+#[cfg(test)]
+pub const DEFAULT_UPLOAD_SESSION_IDLE_TIMEOUT_SECS: u64 = 60 * 60;
 
 pub struct FileState {
     pub uploaded: u64,
@@ -67,6 +69,7 @@ struct StoreState {
 struct SharedState {
     state: std::sync::Mutex<StoreState>,
     notify: Notify,
+    idle_ttl: Duration,
 }
 
 pub struct Store {
@@ -74,7 +77,14 @@ pub struct Store {
 }
 
 impl Store {
+    #[cfg(test)]
     pub fn new() -> Self {
+        Self::with_idle_ttl(Duration::from_secs(
+            DEFAULT_UPLOAD_SESSION_IDLE_TIMEOUT_SECS,
+        ))
+    }
+
+    pub fn with_idle_ttl(idle_ttl: Duration) -> Self {
         let result = Store {
             shared: Arc::new(SharedState {
                 state: std::sync::Mutex::new(StoreState {
@@ -86,6 +96,7 @@ impl Store {
                     shutdown: false,
                 }),
                 notify: Notify::new(),
+                idle_ttl,
             }),
         };
 
@@ -101,8 +112,7 @@ impl Store {
         );
         let removal_id = state.next_id;
         state.next_id += 1;
-        let removal_instant =
-            Instant::now() + Duration::from_secs(UPLOAD_SESSION_IDLE_TIMEOUT_SECS);
+        let removal_instant = Instant::now() + self.shared.idle_ttl;
         state
             .expirations
             .insert((removal_instant, removal_id), id.clone());
@@ -126,7 +136,7 @@ impl Store {
             return;
         };
         state.expirations.remove(&(old_when, removal_id));
-        let new_when = Instant::now() + Duration::from_secs(UPLOAD_SESSION_IDLE_TIMEOUT_SECS);
+        let new_when = Instant::now() + self.shared.idle_ttl;
         state
             .expirations
             .insert((new_when, removal_id), id.to_owned());
@@ -306,7 +316,9 @@ mod tests {
             sender: None,
             sender_attributes: Vec::new(),
             confirm: false,
-            is_api_key: false,
+            notify_recipients: true,
+            api_key_tenant: None,
+            api_key_validation_failed: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Layered on top of the just-merged #132 (60-min idle TTL + per-chunk `Store::touch()`). Two follow-ups that make client-side retry actually work end-to-end:

1. **Structured 404 body for missing upload sessions.** Today `store.get(uuid).ok_or(NotFound)` returns a bare 404 — the client can't tell "session expired" from a real 404. New `Error::UploadSessionNotFound` variant returns `{ \"error\": \"upload_session_not_found\", \"uuid\": \"...\", \"reason\": \"...\" }` with status 404 from both `PUT /fileupload/{uuid}` and `POST /fileupload/finalize/{uuid}`. The `reason` field distinguishes:
   - `expired_or_unknown` — session wasn't in the in-memory store (evicted past idle TTL or never existed)
   - `invalid_uuid` — malformed UUID in the path
   - `file_missing` — in-memory state exists but the on-disk file is gone (server-state inconsistency)

   Clients (the postguard-js retry work coming up) can now decide *not* to retry — these are all unrecoverable, the user needs a fresh upload.

2. **Configurable session TTL.** The 60-min constant from #132 is now driven by `CryptifyConfig::session_ttl_secs` (default 3600s). Avoids another constant-change PR when the Postgres-backed sessions land in Phase 2.

`api-description.yaml` documents the new 404 response shape and the `UploadSessionNotFound` schema for both routes.

## Wire-level compatibility

Existing pg-js clients (≤ v1.3) only check `response.ok`; they don't parse the 404 body. The status code is unchanged (still 404), so this is backwards-compatible — old clients see the same behaviour, new clients can opt into the structured body.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes (42 tests, none regressed)
- [ ] Manual: start cryptify, init an upload, kill the server, restart, push a chunk → response body is `{\"error\":\"upload_session_not_found\",\"uuid\":\"...\",\"reason\":\"expired_or_unknown\"}`
- [ ] Manual: start cryptify with `session_ttl_secs = 5` in the config, init an upload, sleep 6 s, push a chunk → 404 with structured body. Restore default config, sleep 6 s before chunk → still works (deadline gets touched per chunk from #132).

## Refs

- Issue encryption4all/postguard-website#117 (upload robustness — root cause)
- Issue #134 (separately addressed in Phase 2 — Postgres-backed quota)
- Builds on #132 (just merged)
- Required before any pg-js retry work can distinguish session-expired from generic 5xx