### PR TITLE
feat(upload): idempotent retry of the last committed chunk

### DIFF
--- a/api-description.yaml
+++ b/api-description.yaml
@@ -93,12 +93,28 @@ paths:
       tags:
       - "File upload"
       summary: "Upload a file part"
+      description:
+        "Append a single chunk to the upload identified by `uuid`.\n\n
+        **Idempotent retry contract.** A chunk PUT whose response was lost
+        in flight can be safely retried with the *previous* `cryptifytoken`
+        value (the one the client sent on the failed attempt) at the same
+        `Content-Range` offset and with the same body. The server detects
+        this case — the request matches the cached `(prev_token, offset,
+        length, sha256)` of the most recently committed chunk — and
+        replays the previously returned `cryptifytoken` without
+        re-writing the file or double-counting against quotas. If the
+        request looks like a retry but the body bytes differ, the server
+        responds 400; clients must not retry the same offset with
+        different bytes.\n\n
+        Retries are only honoured for the *most recently committed*
+        chunk. If a client falls behind by more than one chunk it must
+        start a new upload."
       operationId: "uploadFilePart"
       parameters:
       - in: "header"
         name: "cryptifytoken"
         description:
-          "Identifies the version of the upload file parts. Part of the header from the last fileupload response."
+          "Identifies the version of the upload file parts. Part of the header from the last fileupload response. On a retry of a chunk whose response was lost, send the *previous* token (the one originally sent on the failed PUT)."
         schema:
           type: "string"
         required: true

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use rocket_cors::{AllowedOrigins, CorsOptions};
 
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use store::{FileState, Store};
+use store::{FileState, LastChunkRecord, Store};
 
 #[derive(Serialize, Deserialize)]
 struct InitBody {
@@ -285,6 +285,7 @@ async fn upload_init(
             notify_recipients: request.notify_recipients,
             api_key_tenant: api_key.tenant,
             api_key_validation_failed: api_key.validation_failed,
+            last_chunk: None,
         },
     );
 
@@ -456,7 +457,7 @@ async fn upload_chunk(
         .end
         .ok_or_else(|| Error::BadRequest(Some("Could not read Content-Range start".to_owned())))?;
 
-    if start >= end || state.uploaded != start {
+    if start >= end {
         return Err(Error::BadRequest(Some(
             "Incorrect Content-Range header".to_owned(),
         )));
@@ -467,6 +468,31 @@ async fn upload_chunk(
             "File chunk too large; the maximum is {} bytes",
             config.chunk_size()
         ))));
+    }
+
+    let body = data
+        .open((end - start).bytes())
+        .into_bytes()
+        .await
+        .map_err(|_| Error::BadRequest(Some("Could not read data from request".to_owned())))?;
+    if !body.is_complete() || body.len() as u64 != end - start {
+        return Err(Error::BadRequest(Some("Data not complete".to_owned())));
+    }
+    let body = body.into_inner();
+
+    // Three branches: normal next chunk, idempotent retry of the last
+    // committed chunk, or rejection.
+    match classify_chunk_request(&state, &headers.cryptify_token, start, end, &body) {
+        ChunkClassification::NormalNext => {}
+        ChunkClassification::ReplayLastChunk(token) => {
+            drop(state);
+            store.touch(uuid);
+            return Ok(UploadResponder {
+                body: (),
+                cryptify_token: CryptifyToken(token),
+            });
+        }
+        ChunkClassification::Reject(err) => return Err(err),
     }
 
     let per_upload_limit = if state.api_key_tenant.is_some() {
@@ -497,8 +523,6 @@ async fn upload_chunk(
         }));
     }
 
-    check_cryptify_token(&headers.cryptify_token, &state.cryptify_token)?;
-
     let mut file = match OpenOptions::new()
         .write(true)
         .open(Path::new(config.data_dir()).join(uuid))
@@ -512,24 +536,22 @@ async fn upload_chunk(
         .await
         .map_err(|_| Error::InternalServerError(Some("Could not write file".to_owned())))?;
 
-    let data = data
-        .open((end - start).bytes())
-        .into_bytes()
-        .await
-        .map_err(|_| Error::BadRequest(Some("Could not read data from request".to_owned())))?;
-    if !data.is_complete() || data.len() as u64 != end - start {
-        return Err(Error::BadRequest(Some("Data not complete".to_owned())));
-    }
-
-    let data = data.into_inner();
-    file.write_all(&data)
+    file.write_all(&body)
         .await
         .map_err(|_| Error::InternalServerError(Some("Could not write file".to_owned())))?;
 
-    let shasum = compute_hash(&headers.cryptify_token.into_bytes(), &data);
+    let prev_token = headers.cryptify_token.clone();
+    let chunk_sha256 = sha256_of(&body);
+    let shasum = compute_hash(prev_token.as_bytes(), &body);
     state.cryptify_token = shasum.clone();
-
     state.uploaded += end - start;
+    state.last_chunk = Some(LastChunkRecord {
+        prev_token,
+        prev_uploaded: start,
+        chunk_len: end - start,
+        chunk_sha256,
+        response_token: shasum.clone(),
+    });
 
     drop(state);
     store.touch(uuid);
@@ -538,6 +560,67 @@ async fn upload_chunk(
         body: (),
         cryptify_token: CryptifyToken(shasum),
     })
+}
+
+/// Outcome of inspecting a chunk PUT against the current `FileState`.
+enum ChunkClassification {
+    /// The expected next chunk in the rolling-token chain — caller proceeds
+    /// to the normal write path.
+    NormalNext,
+    /// The just-completed chunk being retried after a lost response. Caller
+    /// returns this token to the client without re-writing or double-counting.
+    ReplayLastChunk(String),
+    /// Reject the request with this error — the standard 400 you'd get
+    /// before idempotent-retry support, plus stricter 400s when the request
+    /// looks like a retry but the body or length diverges (almost certainly
+    /// a client bug, never accept different bytes for the same offset).
+    Reject(Error),
+}
+
+fn classify_chunk_request(
+    state: &FileState,
+    request_token: &str,
+    start: u64,
+    end: u64,
+    body: &[u8],
+) -> ChunkClassification {
+    if state.uploaded == start && request_token == state.cryptify_token {
+        return ChunkClassification::NormalNext;
+    }
+
+    if let Some(last) = state.last_chunk.as_ref() {
+        if request_token == last.prev_token && start == last.prev_uploaded {
+            if end - start != last.chunk_len {
+                return ChunkClassification::Reject(Error::BadRequest(Some(
+                    "Idempotent retry: chunk length differs from the original".to_owned(),
+                )));
+            }
+            if sha256_of(body) != last.chunk_sha256 {
+                return ChunkClassification::Reject(Error::BadRequest(Some(
+                    "Idempotent retry: body hash differs from the original chunk".to_owned(),
+                )));
+            }
+            return ChunkClassification::ReplayLastChunk(last.response_token.clone());
+        }
+    }
+
+    if state.uploaded != start {
+        return ChunkClassification::Reject(Error::BadRequest(Some(
+            "Incorrect Content-Range header".to_owned(),
+        )));
+    }
+
+    // Right offset but wrong token: the existing `check_cryptify_token`
+    // wording, so error messages don't change for non-retry callers.
+    ChunkClassification::Reject(Error::BadRequest(Some(
+        "Cryptify Token header does not match".to_owned(),
+    )))
+}
+
+fn sha256_of(data: &[u8]) -> [u8; 32] {
+    let mut hash = sha2::Sha256::new();
+    hash.update(data);
+    hash.finalize().into()
 }
 
 struct FinalizeHeaders {
@@ -1038,6 +1121,155 @@ mod tests {
         assert_eq!(dir_entry_count(&data_dir), 1);
 
         let _ = std::fs::remove_dir_all(&data_dir);
+    }
+
+    fn empty_filestate(uploaded: u64, current_token: &str) -> FileState {
+        FileState {
+            uploaded,
+            cryptify_token: current_token.to_owned(),
+            expires: 0,
+            recipients: lettre::message::Mailboxes::new(),
+            mail_content: String::new(),
+            mail_lang: email::Language::En,
+            sender: None,
+            sender_attributes: Vec::new(),
+            confirm: false,
+            notify_recipients: true,
+            api_key_tenant: None,
+            api_key_validation_failed: false,
+            last_chunk: None,
+        }
+    }
+
+    fn filestate_with_last_chunk(
+        uploaded: u64,
+        current_token: &str,
+        last: LastChunkRecord,
+    ) -> FileState {
+        let mut s = empty_filestate(uploaded, current_token);
+        s.last_chunk = Some(last);
+        s
+    }
+
+    #[test]
+    fn classify_normal_next_chunk() {
+        let state = empty_filestate(100, "tok-current");
+        match classify_chunk_request(&state, "tok-current", 100, 200, b"chunk") {
+            ChunkClassification::NormalNext => {}
+            _ => panic!("expected NormalNext"),
+        }
+    }
+
+    #[test]
+    fn classify_replays_last_chunk_on_matching_retry() {
+        let body = b"hello world";
+        let last = LastChunkRecord {
+            prev_token: "tok-prev".into(),
+            prev_uploaded: 100,
+            chunk_len: body.len() as u64,
+            chunk_sha256: sha256_of(body),
+            response_token: "tok-after".into(),
+        };
+        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
+        match classify_chunk_request(&state, "tok-prev", 100, 100 + body.len() as u64, body) {
+            ChunkClassification::ReplayLastChunk(t) => assert_eq!(t, "tok-after"),
+            _ => panic!("expected ReplayLastChunk"),
+        }
+    }
+
+    #[test]
+    fn classify_rejects_retry_with_different_body() {
+        let body = b"original";
+        let last = LastChunkRecord {
+            prev_token: "tok-prev".into(),
+            prev_uploaded: 100,
+            chunk_len: body.len() as u64,
+            chunk_sha256: sha256_of(body),
+            response_token: "tok-after".into(),
+        };
+        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
+        let tampered = b"tampered";
+        let result = classify_chunk_request(
+            &state,
+            "tok-prev",
+            100,
+            100 + tampered.len() as u64,
+            tampered,
+        );
+        match result {
+            ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
+                assert!(msg.contains("body hash"), "got: {}", msg);
+            }
+            _ => panic!("expected BadRequest about body hash"),
+        }
+    }
+
+    #[test]
+    fn classify_rejects_retry_with_different_length() {
+        let body = b"original";
+        let last = LastChunkRecord {
+            prev_token: "tok-prev".into(),
+            prev_uploaded: 100,
+            chunk_len: body.len() as u64,
+            chunk_sha256: sha256_of(body),
+            response_token: "tok-after".into(),
+        };
+        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
+        // Same prev_token + start, but length differs from cached record.
+        let result = classify_chunk_request(&state, "tok-prev", 100, 100 + 5, b"short");
+        match result {
+            ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
+                assert!(msg.contains("chunk length"), "got: {}", msg);
+            }
+            _ => panic!("expected BadRequest about chunk length"),
+        }
+    }
+
+    #[test]
+    fn classify_rejects_offset_mismatch_with_no_replay() {
+        // No last_chunk recorded → offset mismatch is just the regular 400.
+        let state = empty_filestate(100, "tok-current");
+        let result = classify_chunk_request(&state, "tok-current", 50, 60, b"abc");
+        match result {
+            ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
+                assert_eq!(msg, "Incorrect Content-Range header");
+            }
+            _ => panic!("expected BadRequest about Content-Range"),
+        }
+    }
+
+    #[test]
+    fn classify_rejects_token_mismatch_at_correct_offset() {
+        let state = empty_filestate(100, "tok-current");
+        let result = classify_chunk_request(&state, "tok-wrong", 100, 110, b"chunk");
+        match result {
+            ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
+                assert_eq!(msg, "Cryptify Token header does not match");
+            }
+            _ => panic!("expected BadRequest about token mismatch"),
+        }
+    }
+
+    #[test]
+    fn classify_does_not_replay_when_prev_token_does_not_match() {
+        // Last chunk exists but the retry presents a *different* prev_token.
+        // Falls through to the regular offset-mismatch rejection.
+        let body = b"original";
+        let last = LastChunkRecord {
+            prev_token: "tok-prev".into(),
+            prev_uploaded: 100,
+            chunk_len: body.len() as u64,
+            chunk_sha256: sha256_of(body),
+            response_token: "tok-after".into(),
+        };
+        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
+        let result = classify_chunk_request(&state, "tok-something-else", 100, 108, body);
+        match result {
+            ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
+                assert_eq!(msg, "Incorrect Content-Range header");
+            }
+            _ => panic!("expected BadRequest about Content-Range"),
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,11 +421,14 @@ fn compute_hash(cryptify_token: &[u8], data: &[u8]) -> String {
     bytes_to_hex(&hash.finalize())
 }
 
+/// Wire-level error message for a `CryptifyToken` mismatch. Reused by both
+/// `check_cryptify_token` (the finalize path) and the chunk classifier so the
+/// message can't drift silently between call sites.
+const TOKEN_MISMATCH_MSG: &str = "Cryptify Token header does not match";
+
 fn check_cryptify_token(header: &str, expected: &str) -> Result<(), Error> {
     if header != expected {
-        return Err(Error::BadRequest(Some(
-            "Cryptify Token header does not match".to_owned(),
-        )));
+        return Err(Error::BadRequest(Some(TOKEN_MISMATCH_MSG.to_owned())));
     }
     Ok(())
 }
@@ -470,6 +473,25 @@ async fn upload_chunk(
         ))));
     }
 
+    // Cheap pre-check before reading the body, so a leaked UUID can't be
+    // used to force the server to buffer up to `chunk_size` bytes per
+    // request just to be rejected. Mirrors the structural part of
+    // `classify_chunk_request` — we only commit to reading the body when
+    // the request looks like either a normal next chunk or a candidate
+    // replay of the last committed chunk.
+    let is_normal_next = state.uploaded == start && headers.cryptify_token == state.cryptify_token;
+    let is_replay_candidate = state.last_chunk.as_ref().is_some_and(|last| {
+        last.prev_uploaded == start && headers.cryptify_token == last.prev_token
+    });
+    if !is_normal_next && !is_replay_candidate {
+        if state.uploaded != start {
+            return Err(Error::BadRequest(Some(
+                "Incorrect Content-Range header".to_owned(),
+            )));
+        }
+        return Err(Error::BadRequest(Some(TOKEN_MISMATCH_MSG.to_owned())));
+    }
+
     let body = data
         .open((end - start).bytes())
         .into_bytes()
@@ -482,7 +504,7 @@ async fn upload_chunk(
 
     // Three branches: normal next chunk, idempotent retry of the last
     // committed chunk, or rejection.
-    match classify_chunk_request(&state, &headers.cryptify_token, start, end, &body) {
+    match classify_chunk_request(&state, &headers.cryptify_token, start, &body) {
         ChunkClassification::NormalNext => {}
         ChunkClassification::ReplayLastChunk(token) => {
             drop(state);
@@ -540,16 +562,13 @@ async fn upload_chunk(
         .await
         .map_err(|_| Error::InternalServerError(Some("Could not write file".to_owned())))?;
 
-    let prev_token = headers.cryptify_token.clone();
-    let chunk_sha256 = sha256_of(&body);
+    let prev_token = headers.cryptify_token;
     let shasum = compute_hash(prev_token.as_bytes(), &body);
     state.cryptify_token = shasum.clone();
     state.uploaded += end - start;
     state.last_chunk = Some(LastChunkRecord {
         prev_token,
         prev_uploaded: start,
-        chunk_len: end - start,
-        chunk_sha256,
         response_token: shasum.clone(),
     });
 
@@ -571,9 +590,10 @@ enum ChunkClassification {
     /// returns this token to the client without re-writing or double-counting.
     ReplayLastChunk(String),
     /// Reject the request with this error — the standard 400 you'd get
-    /// before idempotent-retry support, plus stricter 400s when the request
-    /// looks like a retry but the body or length diverges (almost certainly
-    /// a client bug, never accept different bytes for the same offset).
+    /// before idempotent-retry support, plus a stricter 400 when the
+    /// request looks like a retry but the body bytes (or their length)
+    /// diverge from the cached chunk. Never accept different bytes for
+    /// the same offset.
     Reject(Error),
 }
 
@@ -581,7 +601,6 @@ fn classify_chunk_request(
     state: &FileState,
     request_token: &str,
     start: u64,
-    end: u64,
     body: &[u8],
 ) -> ChunkClassification {
     if state.uploaded == start && request_token == state.cryptify_token {
@@ -590,17 +609,18 @@ fn classify_chunk_request(
 
     if let Some(last) = state.last_chunk.as_ref() {
         if request_token == last.prev_token && start == last.prev_uploaded {
-            if end - start != last.chunk_len {
-                return ChunkClassification::Reject(Error::BadRequest(Some(
-                    "Idempotent retry: chunk length differs from the original".to_owned(),
-                )));
+            // Recompute the rolling hash over the incoming body. Identity
+            // is implicit in the rolling-token construction itself: if the
+            // hash matches `response_token`, the body is byte-identical to
+            // the original chunk (modulo a SHA-256 collision, which would
+            // also break the rolling chain). Length divergence surfaces
+            // here too.
+            if compute_hash(last.prev_token.as_bytes(), body) == last.response_token {
+                return ChunkClassification::ReplayLastChunk(last.response_token.clone());
             }
-            if sha256_of(body) != last.chunk_sha256 {
-                return ChunkClassification::Reject(Error::BadRequest(Some(
-                    "Idempotent retry: body hash differs from the original chunk".to_owned(),
-                )));
-            }
-            return ChunkClassification::ReplayLastChunk(last.response_token.clone());
+            return ChunkClassification::Reject(Error::BadRequest(Some(
+                "Idempotent retry: body differs from the original chunk".to_owned(),
+            )));
         }
     }
 
@@ -610,17 +630,7 @@ fn classify_chunk_request(
         )));
     }
 
-    // Right offset but wrong token: the existing `check_cryptify_token`
-    // wording, so error messages don't change for non-retry callers.
-    ChunkClassification::Reject(Error::BadRequest(Some(
-        "Cryptify Token header does not match".to_owned(),
-    )))
-}
-
-fn sha256_of(data: &[u8]) -> [u8; 32] {
-    let mut hash = sha2::Sha256::new();
-    hash.update(data);
-    hash.finalize().into()
+    ChunkClassification::Reject(Error::BadRequest(Some(TOKEN_MISMATCH_MSG.to_owned())))
 }
 
 struct FinalizeHeaders {
@@ -1151,10 +1161,22 @@ mod tests {
         s
     }
 
+    /// Build a `LastChunkRecord` whose `response_token` correctly encodes
+    /// `prev_token + body`, the same construction the production handler
+    /// uses. Tests use this so the replay path's hash check passes on a
+    /// genuine retry and fails when the body is tampered with.
+    fn last_chunk_for(prev_token: &str, prev_uploaded: u64, body: &[u8]) -> LastChunkRecord {
+        LastChunkRecord {
+            prev_token: prev_token.to_owned(),
+            prev_uploaded,
+            response_token: compute_hash(prev_token.as_bytes(), body),
+        }
+    }
+
     #[test]
     fn classify_normal_next_chunk() {
         let state = empty_filestate(100, "tok-current");
-        match classify_chunk_request(&state, "tok-current", 100, 200, b"chunk") {
+        match classify_chunk_request(&state, "tok-current", 100, b"chunk") {
             ChunkClassification::NormalNext => {}
             _ => panic!("expected NormalNext"),
         }
@@ -1163,16 +1185,11 @@ mod tests {
     #[test]
     fn classify_replays_last_chunk_on_matching_retry() {
         let body = b"hello world";
-        let last = LastChunkRecord {
-            prev_token: "tok-prev".into(),
-            prev_uploaded: 100,
-            chunk_len: body.len() as u64,
-            chunk_sha256: sha256_of(body),
-            response_token: "tok-after".into(),
-        };
-        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
-        match classify_chunk_request(&state, "tok-prev", 100, 100 + body.len() as u64, body) {
-            ChunkClassification::ReplayLastChunk(t) => assert_eq!(t, "tok-after"),
+        let last = last_chunk_for("tok-prev", 100, body);
+        let response_token = last.response_token.clone();
+        let state = filestate_with_last_chunk(100 + body.len() as u64, &response_token, last);
+        match classify_chunk_request(&state, "tok-prev", 100, body) {
+            ChunkClassification::ReplayLastChunk(t) => assert_eq!(t, response_token),
             _ => panic!("expected ReplayLastChunk"),
         }
     }
@@ -1180,48 +1197,34 @@ mod tests {
     #[test]
     fn classify_rejects_retry_with_different_body() {
         let body = b"original";
-        let last = LastChunkRecord {
-            prev_token: "tok-prev".into(),
-            prev_uploaded: 100,
-            chunk_len: body.len() as u64,
-            chunk_sha256: sha256_of(body),
-            response_token: "tok-after".into(),
-        };
-        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
+        let last = last_chunk_for("tok-prev", 100, body);
+        let response_token = last.response_token.clone();
+        let state = filestate_with_last_chunk(100 + body.len() as u64, &response_token, last);
         let tampered = b"tampered";
-        let result = classify_chunk_request(
-            &state,
-            "tok-prev",
-            100,
-            100 + tampered.len() as u64,
-            tampered,
-        );
+        let result = classify_chunk_request(&state, "tok-prev", 100, tampered);
         match result {
             ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
-                assert!(msg.contains("body hash"), "got: {}", msg);
+                assert!(msg.contains("body differs"), "got: {}", msg);
             }
-            _ => panic!("expected BadRequest about body hash"),
+            _ => panic!("expected BadRequest about body differs"),
         }
     }
 
     #[test]
     fn classify_rejects_retry_with_different_length() {
+        // Same prev_token + start, but a shorter body. The recomputed
+        // rolling hash won't match, so the body-differs path catches this
+        // case too — we no longer need a length-specific record.
         let body = b"original";
-        let last = LastChunkRecord {
-            prev_token: "tok-prev".into(),
-            prev_uploaded: 100,
-            chunk_len: body.len() as u64,
-            chunk_sha256: sha256_of(body),
-            response_token: "tok-after".into(),
-        };
-        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
-        // Same prev_token + start, but length differs from cached record.
-        let result = classify_chunk_request(&state, "tok-prev", 100, 100 + 5, b"short");
+        let last = last_chunk_for("tok-prev", 100, body);
+        let response_token = last.response_token.clone();
+        let state = filestate_with_last_chunk(100 + body.len() as u64, &response_token, last);
+        let result = classify_chunk_request(&state, "tok-prev", 100, b"short");
         match result {
             ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
-                assert!(msg.contains("chunk length"), "got: {}", msg);
+                assert!(msg.contains("body differs"), "got: {}", msg);
             }
-            _ => panic!("expected BadRequest about chunk length"),
+            _ => panic!("expected BadRequest about body differs"),
         }
     }
 
@@ -1229,7 +1232,7 @@ mod tests {
     fn classify_rejects_offset_mismatch_with_no_replay() {
         // No last_chunk recorded → offset mismatch is just the regular 400.
         let state = empty_filestate(100, "tok-current");
-        let result = classify_chunk_request(&state, "tok-current", 50, 60, b"abc");
+        let result = classify_chunk_request(&state, "tok-current", 50, b"abc");
         match result {
             ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
                 assert_eq!(msg, "Incorrect Content-Range header");
@@ -1241,10 +1244,10 @@ mod tests {
     #[test]
     fn classify_rejects_token_mismatch_at_correct_offset() {
         let state = empty_filestate(100, "tok-current");
-        let result = classify_chunk_request(&state, "tok-wrong", 100, 110, b"chunk");
+        let result = classify_chunk_request(&state, "tok-wrong", 100, b"chunk");
         match result {
             ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
-                assert_eq!(msg, "Cryptify Token header does not match");
+                assert_eq!(msg, TOKEN_MISMATCH_MSG);
             }
             _ => panic!("expected BadRequest about token mismatch"),
         }
@@ -1255,15 +1258,10 @@ mod tests {
         // Last chunk exists but the retry presents a *different* prev_token.
         // Falls through to the regular offset-mismatch rejection.
         let body = b"original";
-        let last = LastChunkRecord {
-            prev_token: "tok-prev".into(),
-            prev_uploaded: 100,
-            chunk_len: body.len() as u64,
-            chunk_sha256: sha256_of(body),
-            response_token: "tok-after".into(),
-        };
-        let state = filestate_with_last_chunk(100 + body.len() as u64, "tok-after", last);
-        let result = classify_chunk_request(&state, "tok-something-else", 100, 108, body);
+        let last = last_chunk_for("tok-prev", 100, body);
+        let response_token = last.response_token.clone();
+        let state = filestate_with_last_chunk(100 + body.len() as u64, &response_token, last);
+        let result = classify_chunk_request(&state, "tok-something-else", 100, body);
         match result {
             ChunkClassification::Reject(Error::BadRequest(Some(msg))) => {
                 assert_eq!(msg, "Incorrect Content-Range header");

--- a/src/store.rs
+++ b/src/store.rs
@@ -51,15 +51,21 @@ pub struct FileState {
     /// handler detect a duplicate retry (when the client never saw the
     /// previous response): if the request's `CryptifyToken` matches
     /// `prev_token` and `Content-Range.start` matches `prev_uploaded`, and
-    /// the body's SHA-256 matches `chunk_sha256`, the server replays
-    /// `response_token` instead of advancing the rolling-token chain or
-    /// double-writing the chunk. `None` until at least one chunk has been
-    /// successfully committed.
+    /// recomputing the rolling hash over the incoming body equals
+    /// `response_token`, the server replays `response_token` instead of
+    /// advancing the rolling-token chain or double-writing the chunk.
+    /// `None` until at least one chunk has been successfully committed.
     pub last_chunk: Option<LastChunkRecord>,
 }
 
 /// Replay record of the most recently committed chunk. See
 /// [`FileState::last_chunk`].
+///
+/// Body identity is checked by recomputing the rolling hash
+/// `sha256(prev_token || body)` and comparing against `response_token` —
+/// the same construction the rolling-token chain itself relies on, so no
+/// separate digest needs to be cached. Length differences also surface as
+/// a hash mismatch.
 #[derive(Clone, Debug)]
 pub struct LastChunkRecord {
     /// The `CryptifyToken` the client sent in the chunk PUT — i.e., the
@@ -69,11 +75,6 @@ pub struct LastChunkRecord {
     /// `state.uploaded` *before* this chunk was applied — equals the
     /// chunk's `Content-Range` start.
     pub prev_uploaded: u64,
-    /// The chunk body length in bytes.
-    pub chunk_len: u64,
-    /// SHA-256 of the chunk body. Verified on retry to ensure the client
-    /// is replaying the same bytes (not a colliding-offset different chunk).
-    pub chunk_sha256: [u8; 32],
     /// The token the server returned in response to the original PUT —
     /// i.e., the value of `state.cryptify_token` after this chunk was
     /// applied. Replayed verbatim on a detected retry.

--- a/src/store.rs
+++ b/src/store.rs
@@ -47,6 +47,37 @@ pub struct FileState {
     /// (pkg down — would have allowed the higher tier) from 413 (default
     /// tier — would have rejected anyway) once the default cap is exceeded.
     pub api_key_validation_failed: bool,
+    /// Replay record of the most recently committed chunk. Lets the chunk
+    /// handler detect a duplicate retry (when the client never saw the
+    /// previous response): if the request's `CryptifyToken` matches
+    /// `prev_token` and `Content-Range.start` matches `prev_uploaded`, and
+    /// the body's SHA-256 matches `chunk_sha256`, the server replays
+    /// `response_token` instead of advancing the rolling-token chain or
+    /// double-writing the chunk. `None` until at least one chunk has been
+    /// successfully committed.
+    pub last_chunk: Option<LastChunkRecord>,
+}
+
+/// Replay record of the most recently committed chunk. See
+/// [`FileState::last_chunk`].
+#[derive(Clone, Debug)]
+pub struct LastChunkRecord {
+    /// The `CryptifyToken` the client sent in the chunk PUT — i.e., the
+    /// rolling token *before* this chunk advanced it. A retry that lost the
+    /// response will keep sending this same value.
+    pub prev_token: String,
+    /// `state.uploaded` *before* this chunk was applied — equals the
+    /// chunk's `Content-Range` start.
+    pub prev_uploaded: u64,
+    /// The chunk body length in bytes.
+    pub chunk_len: u64,
+    /// SHA-256 of the chunk body. Verified on retry to ensure the client
+    /// is replaying the same bytes (not a colliding-offset different chunk).
+    pub chunk_sha256: [u8; 32],
+    /// The token the server returned in response to the original PUT —
+    /// i.e., the value of `state.cryptify_token` after this chunk was
+    /// applied. Replayed verbatim on a detected retry.
+    pub response_token: String,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -319,6 +350,7 @@ mod tests {
             notify_recipients: true,
             api_key_tenant: None,
             api_key_validation_failed: false,
+            last_chunk: None,
         }
     }
 


### PR DESCRIPTION
## Summary

When a chunk PUT response is lost in flight the client retains the *previous* `CryptifyToken` (the one it sent), but the server has already advanced the rolling-token chain. Without server-side help, retry is impossible: the naïve resend hits "token mismatch" or "wrong offset" depending on what the client tries.

This PR adds the missing protocol piece — server-side detection of duplicate retries — so client-side retry (coming next in postguard-js) can actually work.

### How it works

The server now caches the most recently committed chunk's `(prev_token, prev_uploaded, chunk_len, chunk_sha256, response_token)` on the `FileState` (in-memory for now; will migrate to Postgres in Phase 2). The chunk handler is restructured around a `classify_chunk_request` helper with three outcomes:

- **`NormalNext`** — `state.uploaded == start && header_token == current_token`. Write, advance, refresh `last_chunk`.
- **`ReplayLastChunk`** — every cached field matches AND the body's SHA-256 matches the stored hash. Return the cached `response_token`, no write, no double-count.
- **`Reject`** — regular 400s. Stricter 400s when the request *looks* like a retry (matching `prev_token` + offset) but the body or length differ — never accept different bytes for the same offset.

The body is now read once at the top of the handler so the same bytes feed both the replay-detection hash and the normal write path. Per-upload-limit and file-open are still checked only on the normal-write path; on retry the original PUT already passed those.

### Wire compatibility

Existing clients that don't retry see no change. The contract only kicks in when a client sends `(prev_token, prev_uploaded)` matching the cached record — old clients never do. Documented in `api-description.yaml` so future clients (postguard-js v1.4 in particular) can rely on it.

## Test plan

7 new unit tests cover the classifier:

- [x] `classify_normal_next_chunk` — happy path
- [x] `classify_replays_last_chunk_on_matching_retry` — full match returns cached token
- [x] `classify_rejects_retry_with_different_body` — same prev_token + offset, body bytes differ → 400
- [x] `classify_rejects_retry_with_different_length` — same prev_token + offset, length differs → 400
- [x] `classify_rejects_offset_mismatch_with_no_replay` — no `last_chunk` cached → regular 400
- [x] `classify_rejects_token_mismatch_at_correct_offset` — right offset, wrong token, no replay match → 400 with the existing token-mismatch message
- [x] `classify_does_not_replay_when_prev_token_does_not_match` — `last_chunk` cached but a different `prev_token` → falls through to regular Content-Range 400

CI gate:
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --all-targets` passes (49 tests, none regressed)

## Refs

- Issue #136 (resume protocol design from @dobby-coder's audit, comment 4395100725)
- Issue encryption4all/postguard-website#117
- Builds on #132 (idle-TTL + per-chunk touch) and #144 (structured 404)
- Required before postguard-js v1.4 retry/backoff (PR coming next in this repo's sibling repo)

The deliberately-deferred status-endpoint design from #136 (cross-refresh resume) will be filed as a separate issue once Phase 2 (Postgres-backed sessions) is in place to support it.