### PR TITLE
ci: add semantic PR title check workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,14 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  lint-pr-title:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/pr-title.yml` to lint PR titles against the [Conventional Commits](https://www.conventionalcommits.org/) spec via [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request), matching the workflow already running in `postguard-website`.

closes #147