### PR TITLE
feat(metrics): pre-seed known channels at zero on startup

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -39,7 +39,6 @@ pub const KNOWN_CHANNELS: &[&str] = &[
 /// and restricted to `[a-z0-9_-]` so it cannot inject Prometheus syntax.
 pub const SOURCE_HEADER: &str = "X-Cryptify-Source";
 
-#[derive(Default)]
 pub struct Metrics {
     uploads: Mutex<BTreeMap<String, u64>>,
     upload_bytes: Mutex<BTreeMap<String, u64>>,
@@ -48,18 +47,32 @@ pub struct Metrics {
     expired_files: AtomicU64,
 }
 
+// `Default` is implemented manually (not derived) so it goes through
+// `Metrics::new()` and pre-seeds `KNOWN_CHANNELS`. A derived `Default`
+// would silently produce an empty-channel object, which diverges from
+// `new()` and re-introduces the missing-baseline problem this module
+// exists to solve.
+impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Metrics {
     pub fn new() -> Self {
-        let m = Self::default();
-        {
-            let mut uploads = m.uploads.lock().unwrap();
-            let mut bytes = m.upload_bytes.lock().unwrap();
-            for c in KNOWN_CHANNELS {
-                uploads.insert((*c).to_string(), 0);
-                bytes.insert((*c).to_string(), 0);
-            }
+        let mut uploads = BTreeMap::new();
+        let mut bytes = BTreeMap::new();
+        for c in KNOWN_CHANNELS {
+            uploads.insert((*c).to_string(), 0u64);
+            bytes.insert((*c).to_string(), 0u64);
         }
-        m
+        Self {
+            uploads: Mutex::new(uploads),
+            upload_bytes: Mutex::new(bytes),
+            storage_bytes: AtomicI64::new(0),
+            active_files: AtomicI64::new(0),
+            expired_files: AtomicU64::new(0),
+        }
     }
 
     /// Record a successfully finalized upload.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -20,6 +20,20 @@ use rocket::http::HeaderMap;
 /// Channel label used when no other source information is present.
 pub const CHANNEL_UNKNOWN: &str = "unknown";
 
+/// Channels pre-seeded at value 0 on startup so dashboards see the full
+/// label set from the first scrape, rather than each channel popping into
+/// existence the first time a request from it lands. Without this, PromQL
+/// `increase()` over a window can read `0` for a channel whose first
+/// observed sample is already non-zero — see #102 follow-up discussion.
+pub const KNOWN_CHANNELS: &[&str] = &[
+    "website",
+    "staging-website",
+    "outlook",
+    "thunderbird",
+    "api",
+    CHANNEL_UNKNOWN,
+];
+
 /// Header clients can set to identify themselves (`outlook`, `thunderbird`,
 /// `api`, ...). Leading whitespace is trimmed and the value is lowercased
 /// and restricted to `[a-z0-9_-]` so it cannot inject Prometheus syntax.
@@ -36,7 +50,16 @@ pub struct Metrics {
 
 impl Metrics {
     pub fn new() -> Self {
-        Self::default()
+        let m = Self::default();
+        {
+            let mut uploads = m.uploads.lock().unwrap();
+            let mut bytes = m.upload_bytes.lock().unwrap();
+            for c in KNOWN_CHANNELS {
+                uploads.insert((*c).to_string(), 0);
+                bytes.insert((*c).to_string(), 0);
+            }
+        }
+        m
     }
 
     /// Record a successfully finalized upload.
@@ -325,11 +348,19 @@ mod tests {
     }
 
     #[test]
-    fn render_emits_zero_counters_when_empty() {
+    fn render_preseeds_known_channels_at_zero() {
         let m = Metrics::new();
         let text = m.render();
-        assert!(text.contains("cryptify_uploads_total{channel=\"unknown\"} 0"));
-        assert!(text.contains("cryptify_upload_bytes_total{channel=\"unknown\"} 0"));
+        for c in KNOWN_CHANNELS {
+            assert!(
+                text.contains(&format!("cryptify_uploads_total{{channel=\"{c}\"}} 0")),
+                "missing zero-seed for uploads channel={c} in:\n{text}"
+            );
+            assert!(
+                text.contains(&format!("cryptify_upload_bytes_total{{channel=\"{c}\"}} 0")),
+                "missing zero-seed for upload_bytes channel={c} in:\n{text}"
+            );
+        }
         assert!(text.contains("cryptify_storage_bytes 0"));
         assert!(text.contains("cryptify_active_files 0"));
         assert!(text.contains("cryptify_expired_files_total 0"));


### PR DESCRIPTION
## Summary
- Pre-seeds the six known channels (`website`, `staging-website`, `outlook`, `thunderbird`, `api`, `unknown`) to `0` for both `cryptify_uploads_total` and `cryptify_upload_bytes_total` in `Metrics::new()`.
- Renames the corresponding test from `render_emits_zero_counters_when_empty` to `render_preseeds_known_channels_at_zero` and iterates over `KNOWN_CHANNELS` so the contract stays self-validating if the list grows.

## Why
Without pre-seeding, Prometheus only registers a series for `{channel="X"}` the first time an upload from that channel finalizes. The very first sample is value `1`, and PromQL `increase(...[1h])` over a window where the series has only post-event samples returns nothing — dashboards then read `0` for a channel that actually saw traffic until ~an hour after the first upload. The effect compounds on every cryptify pod restart (each rollout blanks the in-memory counters).

With this change all six channels emit a `0` line on the first scrape, so:
- `increase(...)` has a `0`-valued baseline to differentiate against.
- Per-channel dashboard panels show every channel from the start, not just the ones that happen to have had traffic since the last rollout.
- The `if uploads.is_empty()` fallback in `render()` becomes effectively dead, but is left in place defensively.

## Test plan
- [x] `cargo test metrics` — 13/13 pass, including the rewritten preseed test that iterates over `KNOWN_CHANNELS`.
- [ ] After deploy: scrape `/metrics` and confirm all six `channel=` rows are present at `0` before any uploads have happened.
- [ ] In Cockpit Grafana Explore: `cryptify_uploads_total` returns six rows (one per channel) immediately on the first scrape post-rollout.