### PR TITLE
feat(metrics): capture X-POSTGUARD-CLIENT-VERSION client identity

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -880,6 +880,8 @@ mod tests {
             ],
             confirm: true,
             source_channel: String::new(),
+            client_version: None,
+            client_app: None,
             notify_recipients: true,
             api_key_tenant: None,
             api_key_validation_failed: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,10 @@ use std::time::Duration;
 use crate::config::CryptifyConfig;
 use crate::email::{render_confirmation_email, render_recipient_email, send_email, RenderedEmail};
 use crate::error::{Error, PayloadTooLargeBody};
-use crate::metrics::{detect_channel, storage_sampler, Metrics};
+use crate::metrics::{
+    detect_channel, parse_client_version, storage_sampler, Metrics, CHANNEL_UNKNOWN,
+    CLIENT_VERSION_HEADER,
+};
 use crate::store::{
     API_KEY_PER_UPLOAD_LIMIT, API_KEY_ROLLING_LIMIT, PER_UPLOAD_LIMIT, ROLLING_LIMIT,
     ROLLING_WINDOW_SECS,
@@ -97,6 +100,13 @@ struct InitResponder {
 /// headers for metrics labelling.
 struct ClientHeaders {
     channel: String,
+    /// Raw `X-POSTGUARD-CLIENT-VERSION` value (`host,host_version,app,app_version`),
+    /// kept verbatim for logging so exact client versions are greppable.
+    client_version: Option<String>,
+    /// The `app` field of the client-version header, used as the
+    /// `cryptify_uploads_by_app_total` metric label. `None` when the header
+    /// is absent or malformed.
+    client_app: Option<String>,
 }
 
 #[rocket::async_trait]
@@ -106,8 +116,18 @@ impl<'r> FromRequest<'r> for ClientHeaders {
     async fn from_request(
         request: &'r rocket::Request<'_>,
     ) -> rocket::request::Outcome<Self, Self::Error> {
+        let client_version = request
+            .headers()
+            .get_one(CLIENT_VERSION_HEADER)
+            .map(str::to_string);
+        let client_app = client_version
+            .as_deref()
+            .and_then(parse_client_version)
+            .map(|cv| cv.app);
         rocket::request::Outcome::Success(ClientHeaders {
             channel: detect_channel(request.headers()),
+            client_version,
+            client_app,
         })
     }
 }
@@ -305,6 +325,13 @@ async fn upload_init(
     let init_cryptify_token = bytes_to_hex(&rand::random::<[u8; 32]>());
     let recovery_token = bytes_to_hex(&rand::random::<[u8; 32]>());
 
+    log::info!(
+        "upload_init uuid={} channel={} client_version={:?}",
+        uuid,
+        client_headers.channel,
+        client_headers.client_version
+    );
+
     store.create(
         uuid.clone(),
         FileState {
@@ -318,6 +345,8 @@ async fn upload_init(
             sender_attributes: Vec::new(),
             confirm: request.confirm,
             source_channel: client_headers.channel,
+            client_version: client_headers.client_version,
+            client_app: client_headers.client_app,
             notify_recipients: request.notify_recipients,
             api_key_tenant: api_key.tenant,
             api_key_validation_failed: api_key.validation_failed,
@@ -824,6 +853,16 @@ async fn upload_finalize(
     })?;
 
     metrics.record_upload(&state.source_channel, state.uploaded);
+    metrics.record_upload_app(state.client_app.as_deref().unwrap_or(CHANNEL_UNKNOWN));
+
+    log::info!(
+        "upload_finalize uuid={} channel={} client_version={:?} app={:?} bytes={}",
+        uuid,
+        state.source_channel,
+        state.client_version,
+        state.client_app,
+        state.uploaded
+    );
 
     if let Some(key) = accounting_key {
         store.record_upload(key, state.uploaded, now_secs);
@@ -1227,6 +1266,10 @@ pub fn build_rocket(figment: Figment, vk: Parameters<VerifyingKey>) -> Rocket<Bu
             "CryptifyToken",
             "Range",
             "X-Recovery-Token",
+            // Browser clients (pg-js) send this on every request; without it
+            // in the preflight allowlist the browser blocks cross-origin
+            // uploads. Captured for the per-app upload metric + logs.
+            "X-POSTGUARD-CLIENT-VERSION",
         ]))
         .expose_headers(["cryptifytoken"].iter().map(ToString::to_string).collect())
         .max_age(Some(86400))
@@ -1891,6 +1934,8 @@ mod tests {
             sender_attributes: Vec::new(),
             confirm: false,
             source_channel: String::new(),
+            client_version: None,
+            client_app: None,
             notify_recipients: true,
             api_key_tenant: None,
             api_key_validation_failed: false,
@@ -2382,6 +2427,8 @@ mod tests {
                 sender_attributes: Vec::new(),
                 confirm: true,
                 source_channel: String::new(),
+                client_version: None,
+                client_app: None,
                 notify_recipients: true,
                 api_key_tenant: None,
                 api_key_validation_failed: false,
@@ -2620,6 +2667,61 @@ mod integration {
 
         let final_status = do_finalize(&client, &uuid, &token, sealed.len() as u64).await;
         assert_eq!(final_status, Status::Ok);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[rocket::async_test]
+    async fn upload_records_client_app_metric() {
+        let mut rng = rand08::thread_rng();
+        let setup = TestSetup::new(&mut rng);
+        let sealed = seal_payload(&setup, b"hello metric test").await;
+
+        let (client, dir) = test_client(&setup).await;
+
+        // Init carrying a client-version header whose `app` field is pg-js.
+        let res = client
+            .post("/fileupload/init")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-POSTGUARD-CLIENT-VERSION",
+                "node,22.1.0,pg-js,1.2.3",
+            ))
+            .body(init_body_json(SENDER_EMAIL))
+            .dispatch()
+            .await;
+        assert_eq!(res.status(), Status::Ok);
+        let mut token = res
+            .headers()
+            .get_one("cryptifytoken")
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+        let body = res.into_string().await.unwrap_or_default();
+        let uuid = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|v| v.get("uuid").and_then(|u| u.as_str().map(String::from)))
+            .unwrap_or_default();
+        assert!(!uuid.is_empty());
+
+        let (chunk_status, next) = do_chunk(&client, &uuid, &token, &sealed, 0).await;
+        assert_eq!(chunk_status, Status::Ok);
+        token = next;
+
+        let final_status = do_finalize(&client, &uuid, &token, sealed.len() as u64).await;
+        assert_eq!(final_status, Status::Ok);
+
+        // The finalized upload is attributed to app="pg-js".
+        let metrics = client
+            .get("/metrics")
+            .dispatch()
+            .await
+            .into_string()
+            .await
+            .unwrap_or_default();
+        assert!(
+            metrics.contains("cryptify_uploads_by_app_total{app=\"pg-js\"} 1"),
+            "expected pg-js app counter in metrics:\n{metrics}"
+        );
 
         let _ = std::fs::remove_dir_all(dir);
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,14 +34,55 @@ pub const KNOWN_CHANNELS: &[&str] = &[
     CHANNEL_UNKNOWN,
 ];
 
+/// Client apps pre-seeded at value 0 on startup so dashboards see the full
+/// label set from the first scrape (same rationale as `KNOWN_CHANNELS`).
+/// These are the `app` field of the `X-POSTGUARD-CLIENT-VERSION` header.
+pub const KNOWN_APPS: &[&str] = &["pg-js", "pg-dotnet", "pg4ol", "pg4tb", CHANNEL_UNKNOWN];
+
 /// Header clients can set to identify themselves (`outlook`, `thunderbird`,
 /// `api`, ...). Leading whitespace is trimmed and the value is lowercased
 /// and restricted to `[a-z0-9_-]` so it cannot inject Prometheus syntax.
 pub const SOURCE_HEADER: &str = "X-Cryptify-Source";
 
+/// Structured client-identity header shared with pg-pkg. Value format is
+/// `host,host_version,app,app_version` (e.g. `node,22.1.0,pg-js,1.2.3` or
+/// `Outlook,1.0,pg4ol,0.0.1`). Captured for logging (the full raw value) and
+/// for the per-app upload metric (the `app` field only).
+pub const CLIENT_VERSION_HEADER: &str = "X-POSTGUARD-CLIENT-VERSION";
+
+/// Parsed form of the `X-POSTGUARD-CLIENT-VERSION` header. All four fields
+/// are kept for completeness and logging/inspection; only `app` is consumed
+/// for the metric label today.
+#[allow(dead_code)]
+pub struct ClientVersion {
+    pub host: String,
+    pub host_version: String,
+    pub app: String,
+    pub app_version: String,
+}
+
+/// Parse the 4-field client-version header. Returns `None` unless the value
+/// has exactly four comma-separated fields (matching pg-pkg's strict
+/// destructuring). Fields are trimmed but otherwise left raw — callers that
+/// want a metric label must `sanitize_label` the `app` field themselves.
+pub fn parse_client_version(raw: &str) -> Option<ClientVersion> {
+    let parts: Vec<&str> = raw.split(',').map(str::trim).collect();
+    if let [host, host_version, app, app_version] = parts[..] {
+        Some(ClientVersion {
+            host: host.to_string(),
+            host_version: host_version.to_string(),
+            app: app.to_string(),
+            app_version: app_version.to_string(),
+        })
+    } else {
+        None
+    }
+}
+
 pub struct Metrics {
     uploads: Mutex<BTreeMap<String, u64>>,
     upload_bytes: Mutex<BTreeMap<String, u64>>,
+    uploads_by_app: Mutex<BTreeMap<String, u64>>,
     storage_bytes: AtomicI64,
     active_files: AtomicI64,
     expired_files: AtomicU64,
@@ -66,9 +107,14 @@ impl Metrics {
             uploads.insert((*c).to_string(), 0u64);
             bytes.insert((*c).to_string(), 0u64);
         }
+        let mut by_app = BTreeMap::new();
+        for a in KNOWN_APPS {
+            by_app.insert((*a).to_string(), 0u64);
+        }
         Self {
             uploads: Mutex::new(uploads),
             upload_bytes: Mutex::new(bytes),
+            uploads_by_app: Mutex::new(by_app),
             storage_bytes: AtomicI64::new(0),
             active_files: AtomicI64::new(0),
             expired_files: AtomicU64::new(0),
@@ -82,6 +128,16 @@ impl Metrics {
         *uploads.entry(channel.clone()).or_insert(0) += 1;
         let mut bytes_map = self.upload_bytes.lock().unwrap();
         *bytes_map.entry(channel).or_insert(0) += bytes;
+    }
+
+    /// Record a finalized upload against the client `app` that sent it (the
+    /// `app` field of `X-POSTGUARD-CLIENT-VERSION`). Cardinality-safe: the
+    /// full version is never a label (it lives in logs); only the sanitized
+    /// app name is used here.
+    pub fn record_upload_app(&self, app: &str) {
+        let app = sanitize_label(app);
+        let mut by_app = self.uploads_by_app.lock().unwrap();
+        *by_app.entry(app).or_insert(0) += 1;
     }
 
     /// Record an upload that expired / was purged without finalizing.
@@ -144,6 +200,29 @@ impl Metrics {
             }
         }
         drop(bytes);
+
+        let _ = writeln!(
+            out,
+            "# HELP cryptify_uploads_by_app_total Total finalized uploads per client app."
+        );
+        let _ = writeln!(out, "# TYPE cryptify_uploads_by_app_total counter");
+        let by_app = self.uploads_by_app.lock().unwrap();
+        if by_app.is_empty() {
+            let _ = writeln!(
+                out,
+                "cryptify_uploads_by_app_total{{app=\"{}\"}} 0",
+                CHANNEL_UNKNOWN
+            );
+        } else {
+            for (app, count) in by_app.iter() {
+                let _ = writeln!(
+                    out,
+                    "cryptify_uploads_by_app_total{{app=\"{}\"}} {}",
+                    app, count
+                );
+            }
+        }
+        drop(by_app);
 
         let _ = writeln!(
             out,
@@ -358,6 +437,55 @@ mod tests {
         assert_eq!(sanitize_label("   "), "unknown");
         let long = "a".repeat(100);
         assert_eq!(sanitize_label(&long).len(), 32);
+    }
+
+    #[test]
+    fn parse_client_version_happy_path() {
+        let cv = parse_client_version("Outlook,1.0,pg4ol,0.0.1").unwrap();
+        assert_eq!(cv.host, "Outlook");
+        assert_eq!(cv.host_version, "1.0");
+        assert_eq!(cv.app, "pg4ol");
+        assert_eq!(cv.app_version, "0.0.1");
+    }
+
+    #[test]
+    fn parse_client_version_trims_fields() {
+        let cv = parse_client_version(" node , 22.1.0 , pg-js , 1.2.3 ").unwrap();
+        assert_eq!(cv.host, "node");
+        assert_eq!(cv.app, "pg-js");
+        assert_eq!(cv.app_version, "1.2.3");
+    }
+
+    #[test]
+    fn parse_client_version_rejects_wrong_field_count() {
+        assert!(parse_client_version("").is_none());
+        assert!(parse_client_version("a,b,c").is_none());
+        assert!(parse_client_version("a,b,c,d,e").is_none());
+    }
+
+    #[test]
+    fn record_upload_app_aggregates_and_sanitizes() {
+        let m = Metrics::new();
+        m.record_upload_app("pg-js");
+        m.record_upload_app("pg-js");
+        m.record_upload_app("pg-dotnet");
+        // Unsafe input is sanitized to the same label as the clean form.
+        m.record_upload_app("pg-js\n\"}");
+        let text = m.render();
+        assert!(text.contains("cryptify_uploads_by_app_total{app=\"pg-js\"} 3"));
+        assert!(text.contains("cryptify_uploads_by_app_total{app=\"pg-dotnet\"} 1"));
+    }
+
+    #[test]
+    fn render_preseeds_known_apps_at_zero() {
+        let m = Metrics::new();
+        let text = m.render();
+        for a in KNOWN_APPS {
+            assert!(
+                text.contains(&format!("cryptify_uploads_by_app_total{{app=\"{a}\"}} 0")),
+                "missing zero-seed for app={a} in:\n{text}"
+            );
+        }
     }
 
     #[test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -35,6 +35,15 @@ pub struct FileState {
     /// Traffic source this upload originated from ("website", "outlook",
     /// "thunderbird", "api", ...). Used only for metrics labelling.
     pub source_channel: String,
+    /// Raw `X-POSTGUARD-CLIENT-VERSION` header value
+    /// (`host,host_version,app,app_version`) sent by the client, captured at
+    /// init. Logged verbatim at init and finalize so exact client versions are
+    /// greppable. `None` when the header was absent.
+    pub client_version: Option<String>,
+    /// The `app` field parsed out of `client_version` (e.g. "pg-js",
+    /// "pg-dotnet", "pg4ol"). Used as the `cryptify_uploads_by_app_total`
+    /// metric label at finalize. `None` when absent or malformed.
+    pub client_app: Option<String>,
     /// When false, the recipient notification email is suppressed (the
     /// recipients still appear in the parsed list, but the SMTP delivery
     /// loop in `send_email` is skipped). The sender confirmation, if
@@ -387,6 +396,8 @@ mod tests {
             sender_attributes: Vec::new(),
             confirm: false,
             source_channel: String::new(),
+            client_version: None,
+            client_app: None,
             notify_recipients: true,
             api_key_tenant: None,
             api_key_validation_failed: false,


### PR DESCRIPTION
## What

Capture the `X-POSTGUARD-CLIENT-VERSION` header (`host,host_version,app,app_version`, reused verbatim from pg-pkg) on uploads so we can see which client software + version is hitting Cryptify.

- Parse the 4-field header in `metrics.rs` (`parse_client_version`, strict 4-field match like pg-pkg).
- **Log** the full raw value at `upload_init` and `upload_finalize` (so exact versions are greppable in logs/Loki — discovery is the goal).
- **Metric**: new cardinality-safe `cryptify_uploads_by_app_total{app}` counter (the `app` field only, e.g. `pg-js`, `pg-dotnet`, `pg4ol`; the full version stays in logs to avoid label explosion). `KNOWN_APPS` pre-seeded at 0.
- Add `X-POSTGUARD-CLIENT-VERSION` to the **CORS allowlist** so browser `pg-js` can send it (the PKG already allowlists it).

## Why

We're promoting PostGuard to production and need to know which (old) client versions are in the wild so we don't break them. The PKG already records this header; Cryptify did not.

## Notes

Covered by unit tests (`parse_client_version` happy/short/long/empty, `record_upload_app` aggregation + sanitisation, `render` pre-seed, and a full init→finalize handler test asserting the metric increments). `cargo test`: 125 passing.