### PR TITLE
feat: configurable email attribute type for the finalize sender check

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct RawCryptifyConfig {
     staging_mode: Option<bool>,
     metrics_token: Option<String>,
     usage_db: Option<String>,
+    email_attribute: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -43,6 +44,11 @@ pub struct CryptifyConfig {
     /// (the in-memory map in `Store` is only a cache). `None` keeps usage
     /// entirely in memory, as it was before persistence was added.
     usage_db: Option<String>,
+    /// Attribute type carrying the sender's email in the signing identity
+    /// (postguard#236). Finalize requires this attribute to be present.
+    /// Test environments override it with a test-scheme type (e.g.
+    /// `irma-demo.sidn-pbdf.email.email`); production keeps the default.
+    email_attribute: String,
 }
 
 impl From<RawCryptifyConfig> for CryptifyConfig {
@@ -67,6 +73,9 @@ impl From<RawCryptifyConfig> for CryptifyConfig {
             staging_mode: config.staging_mode.unwrap_or(false),
             metrics_token: config.metrics_token,
             usage_db: config.usage_db,
+            email_attribute: config
+                .email_attribute
+                .unwrap_or_else(|| "pbdf.sidn-pbdf.email.email".to_owned()),
         }
     }
 }
@@ -141,6 +150,12 @@ impl CryptifyConfig {
         self.usage_db.as_deref()
     }
 
+    /// The attribute type carrying the sender's email in the signing
+    /// identity. Defaults to the production `pbdf.sidn-pbdf.email.email`.
+    pub fn email_attribute(&self) -> &str {
+        &self.email_attribute
+    }
+
     #[cfg(test)]
     pub(crate) fn for_test(server_url: &str, staging_mode: bool) -> Self {
         CryptifyConfig {
@@ -160,6 +175,7 @@ impl CryptifyConfig {
             staging_mode,
             metrics_token: None,
             usage_db: None,
+            email_attribute: "pbdf.sidn-pbdf.email.email".to_owned(),
         }
     }
 }
@@ -195,5 +211,21 @@ mod tests {
             .extract()
             .unwrap();
         assert_eq!(config.usage_db(), None);
+    }
+
+    #[test]
+    fn email_attribute_defaults_to_production_type() {
+        let config: CryptifyConfig = Figment::from(Serialized::defaults(base_config()))
+            .extract()
+            .unwrap();
+        assert_eq!(config.email_attribute(), "pbdf.sidn-pbdf.email.email");
+    }
+
+    #[test]
+    fn email_attribute_is_overridable() {
+        let mut raw = base_config();
+        raw["email_attribute"] = serde_json::json!("irma-demo.sidn-pbdf.email.email");
+        let config: CryptifyConfig = Figment::from(Serialized::defaults(raw)).extract().unwrap();
+        assert_eq!(config.email_attribute(), "irma-demo.sidn-pbdf.email.email");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -933,11 +933,17 @@ async fn upload_finalize(
         .pub_id
         .con;
 
+    // The attribute type carrying the sender's email is configurable
+    // (postguard#236): test environments use a test-scheme type since pbdf
+    // credentials cannot be issued outside production.
+    let email_attribute = config.email_attribute();
     let sender = attributes
         .iter()
-        .find(|x| x.atype == "pbdf.sidn-pbdf.email.email")
+        .find(|x| x.atype == email_attribute)
         .ok_or_else(|| {
-            log::error!("finalized upload has no email attribute in postguard metadata");
+            log::error!(
+                "finalized upload has no email attribute ({email_attribute}) in postguard metadata"
+            );
             Error::InternalServerError(Some(GENERIC_INTERNAL_ERROR_MSG.to_owned()))
         })?
         .value
@@ -945,7 +951,7 @@ async fn upload_finalize(
 
     let sender_attributes: Vec<(String, String)> = attributes
         .into_iter()
-        .filter(|x| x.atype != "pbdf.sidn-pbdf.email.email")
+        .filter(|x| x.atype != email_attribute)
         .filter_map(|x| {
             let atype = x.atype;
             x.value.map(|v| (atype, v))


### PR DESCRIPTION
Part 2 of encryption4all/postguard#236 (Phase 2 of EPIC encryption4all/postguard#201) — the cryptify leg; companion to encryption4all/postguard#244 (PKG) and a pg-js PR to follow.

**Problem:** `upload_finalize` rejects any upload whose sender identity lacks exactly `pbdf.sidn-pbdf.email.email` — a hidden contract the e2e harness discovered, and one of the three hardcodings that make it impossible to run real client flows in a test environment (no test env can issue `pbdf.*` credentials).

**Change:** new `email_attribute` config key (defaults to the production value — deployed configs unaffected). Finalize's sender lookup and the sender-attributes filter both use it. The e2e stack will set `irma-demo.sidn-pbdf.email.email` — the public demo scheme mirrors the email credential with published issuer keys, so the harness gets real email semantics on the identical code path.

Tests: config default + override parse tests; full suite 149 + 2 green; clippy clean (`-D warnings`).